### PR TITLE
depend on traits rather than on injected step(s)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -65,9 +65,10 @@ potter-controller:
           - --test-type nolandscaper
           output_dir: integration_test
         helm:
+          trait_depends:
+          - publish
           depends:
           - run_integration_test
-          - publish
           execute:
           - build_and_push_helm.py
         update_release:
@@ -77,6 +78,7 @@ potter-controller:
             BACKEND_TEST_PATH: backend_test_path
           execute:
           - update_release.py
-          depends:
+          trait_depends:
           - release
+          depends:
           - run_integration_test


### PR DESCRIPTION
**What this PR does / why we need it**:
prepare switching to kaniko as default builder