### PR TITLE
Update apiversions

### DIFF
--- a/config/crd/bases/kappctrl.k14s.io_app.yaml
+++ b/config/crd/bases/kappctrl.k14s.io_app.yaml
@@ -1,27 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apps.kappctrl.k14s.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.friendlyDescription
-    description: Friendly description
-    name: Description
-    type: string
-  - JSONPath: .status.deploy.startedAt
-    description: Last time app started being deployed. Does not mean anything was
-      changed.
-    name: Since-Deploy
-    type: date
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created.
-      It is not guaranteed to be set in happens-before order across separate operations.
-      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists.
-      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-    name: Age
-    type: date
   group: kappctrl.k14s.io
   names:
     kind: App
@@ -29,9 +10,42 @@ spec:
     plural: apps
     singular: app
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
+    additionalPrinterColumns:
+      - jsonPath: .status.friendlyDescription
+        description: Friendly description
+        name: Description
+        type: string
+      - jsonPath: .status.deploy.startedAt
+        description: Last time app started being deployed. Does not mean anything was
+          changed.
+        name: Since-Deploy
+        type: date
+      - jsonPath: .metadata.creationTimestamp
+        description: |-
+          CreationTimestamp is a timestamp representing the server time when this object was created.
+          It is not guaranteed to be set in happens-before order across separate operations.
+          Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          Populated by the system. Read-only. Null for lists.
+          More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+        name: Age
+        type: date
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+          status:
+            type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/config/deployments/webhooks/clusterBomAdmissionHookConfig.yaml
+++ b/config/deployments/webhooks/clusterBomAdmissionHookConfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: clusterbomadmission.hub.k8s.sap.com

--- a/config/deployments/webhooks/secretAdmissionHookConfig.yaml
+++ b/config/deployments/webhooks/secretAdmissionHookConfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: secretadmission.hub.k8s.sap.com


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the `apiVersion` of:

- the MutatingWebhookConfigurations for ClusterBoms and Secrets,  
- the CustomResourceDefinition for Apps.  

The current `appVersion` is no longer supported in kubernetes 1.22.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
